### PR TITLE
Add canonicalize_headers, HTTP insentive headers

### DIFF
--- a/unixrack.rb
+++ b/unixrack.rb
@@ -179,8 +179,8 @@ module UnixRack
       @hdr_method = @hdr_method_line.split(" ")
 
       @hdr_field_lines = @hdr_lines.slice(1..-1) # would prefer first, and rest
-      @headers = @hdr_field_lines.inject({}) { |h, line| k, v = line.split(": "); h[k] = v; h }
-      @headers = canonicalize_headers(@headers)
+      headers = @hdr_field_lines.inject({}) { |h, line| k, v = line.split(": "); h[k] = v; h }
+      @headers = canonicalize_headers(headers)
       true
     end
 

--- a/unixrack.rb
+++ b/unixrack.rb
@@ -180,9 +180,18 @@ module UnixRack
 
       @hdr_field_lines = @hdr_lines.slice(1..-1) # would prefer first, and rest
       @headers = @hdr_field_lines.inject({}) { |h, line| k, v = line.split(": "); h[k] = v; h }
+      @headers = canonicalize_headers(@headers)
       true
     end
 
+    private
+
+    def canonicalize_headers(headers)
+      headers.keys.each do |key|
+        headers[key.split(/-/).map(&:capitalize).join('-')] = headers.delete(key)
+      end
+      headers
+    end
   end
 end
 


### PR DESCRIPTION
Used keys such as "Content-Length" without checking before hand the 
format of the HTTP header keys. The version of Apache Bench of Ubuntu
12.04, for instance, would send headers of the form "Content-length"
causing unixrack to fail with HTTP status 400 and message "Bad Request 
no content-length".
